### PR TITLE
Update contact QR title and layout

### DIFF
--- a/src/pages/story/scenes/ContactScene.jsx
+++ b/src/pages/story/scenes/ContactScene.jsx
@@ -6,12 +6,15 @@ export default function ContactScene({ scene }) {
     <div className="story-scene story-scene--contact">
       <SceneHeading scene={scene} />
       <div className="story-contact-grid">
-        <div className="story-contact-block">
-          <h2>Contact</h2>
+        <div className="story-contact-block story-contact-block--qr-only">
+          <h2>Explore this presentation</h2>
           <div className="story-contact-qr">
             <img src={qrPlaceholder} alt="Scan the QR code to save these contact details" />
             <span>Scan to save our details</span>
           </div>
+        </div>
+        <div className="story-contact-block story-contact-block--details">
+          <h2>Contact</h2>
           <ul>
             {(scene?.contacts || []).map((item) => (
               <li key={item.label}>
@@ -46,16 +49,6 @@ export default function ContactScene({ scene }) {
         </div>
         <div className="story-contact-block story-contact-apply">
           <h2>How to apply</h2>
-          {scene?.apply?.href ? (
-            <a
-              className="btn story-contact-apply-btn"
-              href={scene.apply.href}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {scene.apply.label || "Apply now"}
-            </a>
-          ) : null}
           {Array.isArray(scene?.apply?.details) && scene.apply.details.length > 0 ? (
             <ul className="story-contact-apply-details">
               {scene.apply.details.map((row) => (
@@ -65,6 +58,16 @@ export default function ContactScene({ scene }) {
                 </li>
               ))}
             </ul>
+          ) : null}
+          {scene?.apply?.href ? (
+            <a
+              className="btn story-contact-apply-btn"
+              href={scene.apply.href}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {scene.apply.label || "Apply now"}
+            </a>
           ) : null}
         </div>
       </div>

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -632,9 +632,25 @@
 
 .story-contact-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(4, minmax(220px, 1fr));
   gap: clamp(16px, 3vw, 24px);
   align-items: stretch;
+}
+
+.story-contact-block--qr-only {
+  justify-items: center;
+  align-content: center;
+  padding: clamp(14px, 2.4vw, 20px);
+  text-align: center;
+}
+
+.story-contact-block--qr-only h2 {
+  justify-self: stretch;
+  text-align: left;
+}
+
+.story-contact-block--details {
+  align-content: start;
 }
 
 .story-contact-block {
@@ -650,15 +666,11 @@
 .story-contact-qr {
   display: grid;
   justify-items: center;
-  gap: 10px;
-  padding: 12px;
-  border-radius: 18px;
-  background: rgba(17, 24, 39, 0.04);
-  border: 1px dashed rgba(17, 24, 39, 0.16);
+  gap: 12px;
 }
 
 .story-contact-qr img {
-  width: 148px;
+  width: min(200px, 100%);
   height: auto;
 }
 
@@ -709,7 +721,7 @@
 
 .story-contact-links {
   gap: 12px;
-  justify-items: center;
+  justify-items: stretch;
   width: 100%;
 }
 
@@ -719,7 +731,7 @@
 
 .story-contact-link {
   display: block;
-  width: min(100%, 260px);
+  width: 100%;
   padding: 14px 18px;
   border-radius: 18px;
   background: rgba(17, 24, 39, 0.05);
@@ -742,8 +754,29 @@
 }
 
 .story-contact-apply {
-  align-content: start;
-  justify-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.story-contact-apply > * {
+  width: 100%;
+}
+
+@media (max-width: 1080px) {
+  .story-contact-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .story-contact-block--qr-only {
+    padding: clamp(16px, 3vw, 24px);
+  }
+}
+
+@media (max-width: 600px) {
+  .story-contact-block--qr-only {
+    display: none;
+  }
 }
 
 .story-contact-apply-btn {
@@ -759,6 +792,7 @@
   box-shadow: 0 22px 50px rgba(17, 24, 39, 0.22);
   isolation: isolate;
   width: 100%;
+  margin-top: auto;
 }
 
 .story-contact-apply-btn::after {


### PR DESCRIPTION
## Summary
- retitle the QR column to "Explore this presentation" to match the requested copy
- remove the dashed inner container around the QR code so the image can display at full size
- allow the QR image to scale up slightly now that it is no longer boxed in

## Testing
- npm run lint *(fails: pre-existing unused-variable errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68dacea7d1e8832aa6afbd331b68bb9c