### PR TITLE
Refine year carousel spacing and controls

### DIFF
--- a/src/pages/story/scenes/YearScene.jsx
+++ b/src/pages/story/scenes/YearScene.jsx
@@ -1,8 +1,27 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import SceneHeading from "../components/SceneHeading.jsx";
 import programmeInfo from "../../../data/programmeInfo.json";
 
 export default function YearScene({ scene }) {
+  const tiles = Array.isArray(scene?.tiles) ? scene.tiles : [];
+  const slides = tiles
+    .map((tile, index) => (tile?.image ? { ...tile, tileIndex: index } : null))
+    .filter(Boolean);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!slides.length) {
+      setActiveIndex(0);
+      return;
+    }
+    setActiveIndex((current) => {
+      if (current < 0 || current >= slides.length) {
+        return 0;
+      }
+      return current;
+    });
+  }, [slides.length]);
+
   const programmeOutcomes = useMemo(() => {
     if (!Array.isArray(scene?.outcomeCodes) || !Array.isArray(programmeInfo?.outcomes)) {
       return [];
@@ -12,42 +31,122 @@ export default function YearScene({ scene }) {
       .filter(Boolean);
   }, [scene?.outcomeCodes]);
 
+  const handleSelectSlide = (index) => {
+    if (!Number.isInteger(index)) return;
+    setActiveIndex((current) => {
+      if (!slides.length) return current;
+      const boundedIndex = ((index % slides.length) + slides.length) % slides.length;
+      return boundedIndex;
+    });
+  };
+
+  const handleKeyDown = (event, index) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleSelectSlide(index);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (!slides.length) return;
+    handleSelectSlide(activeIndex - 1);
+  };
+
+  const handleNext = () => {
+    if (!slides.length) return;
+    handleSelectSlide(activeIndex + 1);
+  };
+
   return (
     <div className="story-scene story-scene--year">
       <SceneHeading scene={scene} />
-      <div className="story-year-grid">
-        {(scene?.tiles || []).map((tile) => {
-          const themes = Array.isArray(tile?.themes)
-            ? tile.themes.filter((theme) => Boolean(theme && String(theme).trim()))
-            : [];
-          const hasImage = Boolean(tile?.image);
-          const hasThemes = themes.length > 0;
+      <div className="story-year-layout">
+        <div className="story-year-themes-column">
+          {tiles.map((tile, index) => {
+            const slideIndex = slides.findIndex((slide) => slide.tileIndex === index);
+            const isInteractive = slideIndex !== -1;
+            const isActive = slideIndex === activeIndex && isInteractive;
 
-          return (
-            <article key={tile.track} className="story-year-card">
-              <header>
+            const handleInteraction = () => {
+              if (!isInteractive) return;
+              handleSelectSlide(slideIndex);
+            };
+
+            return (
+              <article
+                key={tile.track}
+                className={`story-year-theme-card${isActive ? " is-active" : ""}`}
+                tabIndex={isInteractive ? 0 : -1}
+                role="button"
+                aria-pressed={isActive}
+                aria-disabled={!isInteractive}
+                onClick={handleInteraction}
+                onMouseEnter={handleInteraction}
+                onFocus={handleInteraction}
+                onKeyDown={(event) => {
+                  if (!isInteractive) return;
+                  handleKeyDown(event, slideIndex);
+                }}
+              >
                 <p className="story-journey-track">{tile.track}</p>
-                {tile?.deliverable ? (
-                  <p className="story-journey-deliverable">{tile.deliverable}</p>
-                ) : null}
-              </header>
-              {hasImage || hasThemes ? (
-                <div className="story-year-card-content">
-                  {hasImage ? (
-                    <div className="story-journey-image" style={{ backgroundImage: `url(${tile.image})` }} />
-                  ) : null}
-                  {hasThemes ? (
-                    <ul className="story-year-themes" role="list">
-                      {themes.map((theme) => (
-                        <li key={theme}>{theme}</li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
-              ) : null}
-            </article>
-          );
-        })}
+              </article>
+            );
+          })}
+        </div>
+        {slides.length ? (
+          <div className="story-year-carousel" aria-live="polite">
+            <div className="story-year-carousel-viewport">
+              {slides.map((slide, index) => {
+                const isActive = index === activeIndex;
+                return (
+                  <figure
+                    key={`${slide.track}-${slide.image}`}
+                    className={`story-year-carousel-slide${isActive ? " is-active" : ""}`}
+                    style={{ backgroundImage: `url(${slide.image})` }}
+                    aria-hidden={!isActive}
+                  >
+                    <figcaption>
+                      <span className="story-year-carousel-track">{slide.track}</span>
+                    </figcaption>
+                  </figure>
+                );
+              })}
+              <button
+                type="button"
+                className="story-year-carousel-nav story-year-carousel-nav--previous"
+                onClick={handlePrevious}
+                aria-label="Previous project"
+              >
+                ‹
+              </button>
+              <button
+                type="button"
+                className="story-year-carousel-nav story-year-carousel-nav--next"
+                onClick={handleNext}
+                aria-label="Next project"
+              >
+                ›
+              </button>
+            </div>
+            <div className="story-year-carousel-dots" role="tablist" aria-label="Select project">
+              {slides.map((slide, index) => {
+                const isActive = index === activeIndex;
+                return (
+                  <button
+                    key={`${slide.track}-dot`}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    className={`story-year-carousel-dot${isActive ? " is-active" : ""}`}
+                    onClick={() => handleSelectSlide(index)}
+                  >
+                    <span className="sr-only">{slide.track}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
       </div>
       {programmeOutcomes.length ? (
         <div className="story-year-outcomes">

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -190,45 +190,196 @@
   color: rgba(17, 24, 39, 0.8);
 }
 
-.story-year-grid {
+.story-year-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(16px, 3vw, 28px);
+  grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+  gap: clamp(18px, 4vw, 36px);
+  align-items: stretch;
 }
 
-.story-year-card {
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 22px;
-  padding: clamp(16px, 2.8vw, 24px);
-  display: grid;
-  gap: 14px;
-  box-shadow: 0 20px 48px rgba(17, 24, 39, 0.12);
-}
-
-.story-year-card-content {
-  display: grid;
-  gap: clamp(14px, 2.5vw, 22px);
-}
-
-.story-year-themes {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.story-year-themes-column {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: clamp(12px, 2.8vw, 20px);
+}
+
+.story-year-theme-card {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 22px;
+  padding: clamp(18px, 2.8vw, 24px);
+  box-shadow: 0 16px 36px rgba(17, 24, 39, 0.12);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  outline: none;
+}
+
+.story-year-theme-card[aria-disabled="true"] {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.story-year-theme-card:hover,
+.story-year-theme-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 44px rgba(17, 24, 39, 0.18);
+}
+
+.story-year-theme-card.is-active {
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 52px rgba(17, 24, 39, 0.2);
+}
+
+.story-year-theme-card[role="button"]:focus-visible {
+  outline: 3px solid rgba(17, 24, 39, 0.4);
+  outline-offset: 4px;
+}
+
+
+.story-year-carousel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2.2vw, 18px);
+}
+
+.story-year-carousel-viewport {
+  position: relative;
+  overflow: hidden;
+  border-radius: 22px;
+  background: rgba(17, 24, 39, 0.4);
+  min-height: clamp(240px, 36vw, 420px);
+}
+
+.story-year-carousel-slide {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  border-radius: 22px;
+  opacity: 0;
+  transform: scale(0.96);
+  transition: opacity 420ms ease, transform 420ms ease;
+}
+
+.story-year-carousel-slide::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(17, 24, 39, 0) 45%, rgba(17, 24, 39, 0.65) 100%);
+  border-radius: inherit;
+}
+
+.story-year-carousel-slide.is-active {
+  opacity: 1;
+  transform: scale(1);
+  z-index: 1;
+}
+
+.story-year-carousel-slide figcaption {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: clamp(14px, 2.4vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #fefce8;
+  z-index: 2;
+}
+
+.story-year-carousel-track {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+
+.story-year-carousel-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: clamp(34px, 4vw, 44px);
+  height: clamp(34px, 4vw, 44px);
+  border-radius: 999px;
+  border: none;
+  background: rgba(17, 24, 39, 0.4);
+  color: #fefce8;
+  font-size: clamp(20px, 2.8vw, 26px);
+  font-weight: 500;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.story-year-carousel-nav--previous {
+  left: clamp(10px, 1.8vw, 18px);
+}
+
+.story-year-carousel-nav--next {
+  right: clamp(10px, 1.8vw, 18px);
+}
+
+.story-year-carousel-nav:hover,
+.story-year-carousel-nav:focus-visible {
+  background: rgba(17, 24, 39, 0.6);
+  transform: translateY(-50%) scale(1.05);
+}
+
+.story-year-carousel-nav:focus-visible {
+  outline: 2px solid rgba(254, 252, 232, 0.75);
+  outline-offset: 2px;
+}
+
+.story-year-carousel-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 10px;
 }
 
-.story-year-themes li {
-  margin: 0;
-  padding: 8px 14px;
-  border-radius: 999px;
-  background: rgba(17, 24, 39, 0.08);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(17, 24, 39, 0.7);
+.story-year-carousel-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.story-year-carousel-dot.is-active {
+  background: #fef3c7;
+  transform: scale(1.15);
+}
+
+.story-year-carousel-dot:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 900px) {
+  .story-year-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .story-year-carousel {
+    order: -1;
+  }
 }
 
 .story-year-outcomes {
@@ -514,16 +665,11 @@
 
 .story-journey-track {
   margin: 0;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(17, 24, 39, 0.6);
-}
-
-.story-journey-deliverable {
-  margin: 6px 0 0;
+  font-size: clamp(16px, 2.4vw, 20px);
   font-weight: 600;
-  color: #111827;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(17, 24, 39, 0.75);
 }
 
 .story-journey-image {


### PR DESCRIPTION
## Summary
- simplify the year scene theme cards and carousel to drop deliverable text so only the three themes and imagery remain
- refresh the associated story page styles to suit the leaner theme card content
- overlay minimal previous/next controls directly on the carousel imagery and remove outer padding so the student work fills the column edge to edge

## Testing
- npm run lint *(fails: existing unused variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dadae5a38c832a9580cd79e6724031