### PR TITLE
Adjust year scenes design studio content

### DIFF
--- a/src/data/storyScenes.json
+++ b/src/data/storyScenes.json
@@ -105,7 +105,7 @@
       "year": "1",
       "tiles": [
         {
-          "track": "Design",
+          "track": "Design Studio",
           "deliverable": "Exploring your first neighbourhood project",
           "image": "images/journey/year1-design.jpg",
           "themes": ["Studio"]
@@ -133,7 +133,7 @@
       "year": "2",
       "tiles": [
         {
-          "track": "Design",
+          "track": "Design Studio",
           "deliverable": "Designing larger urban spaces",
           "image": "images/journey/year2-design.jpg",
           "themes": ["Studio"]
@@ -161,7 +161,7 @@
       "year": "3",
       "tiles": [
         {
-          "track": "Design",
+          "track": "Design Studio",
           "deliverable": "Your final design thesis",
           "image": "images/journey/year3-design.jpg",
           "themes": ["Studio"]

--- a/src/pages/story/scenes/YearScene.jsx
+++ b/src/pages/story/scenes/YearScene.jsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import SceneHeading from "../components/SceneHeading.jsx";
-import programmeInfo from "../../../data/programmeInfo.json";
 
 export default function YearScene({ scene }) {
   const tiles = Array.isArray(scene?.tiles) ? scene.tiles : [];
@@ -21,15 +20,6 @@ export default function YearScene({ scene }) {
       return current;
     });
   }, [slides.length]);
-
-  const programmeOutcomes = useMemo(() => {
-    if (!Array.isArray(scene?.outcomeCodes) || !Array.isArray(programmeInfo?.outcomes)) {
-      return [];
-    }
-    return scene.outcomeCodes
-      .map((code) => programmeInfo.outcomes.find((outcome) => outcome?.code === code))
-      .filter(Boolean);
-  }, [scene?.outcomeCodes]);
 
   const handleSelectSlide = (index) => {
     if (!Number.isInteger(index)) return;
@@ -88,7 +78,12 @@ export default function YearScene({ scene }) {
                   handleKeyDown(event, slideIndex);
                 }}
               >
-                <p className="story-journey-track">{tile.track}</p>
+                <div className="story-year-theme-header">
+                  <h3 className="story-year-theme-title">{tile.track}</h3>
+                  {tile?.deliverable ? (
+                    <p className="story-year-theme-subtitle">{tile.deliverable}</p>
+                  ) : null}
+                </div>
               </article>
             );
           })}
@@ -148,20 +143,6 @@ export default function YearScene({ scene }) {
           </div>
         ) : null}
       </div>
-      {programmeOutcomes.length ? (
-        <div className="story-year-outcomes">
-          <h3 className="story-year-outcomes-title">Programme outcomes highlighted this year</h3>
-          <ul>
-            {programmeOutcomes.map((outcome) => (
-              <li key={outcome.code}>
-                <span className="story-year-outcome-code">{outcome.code}</span>
-                <span className="story-year-outcome-text">{outcome.description}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-      {scene?.footnote ? <p className="story-footnote">{scene.footnote}</p> : null}
     </div>
   );
 }

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -213,6 +213,28 @@
   outline: none;
 }
 
+.story-year-theme-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.story-year-theme-title {
+  margin: 0;
+  font-size: clamp(15px, 2.2vw, 18px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(17, 24, 39, 0.75);
+}
+
+.story-year-theme-subtitle {
+  margin: 0;
+  font-size: clamp(13px, 2vw, 15px);
+  line-height: 1.45;
+  color: rgba(17, 24, 39, 0.68);
+}
+
 .story-year-theme-card[aria-disabled="true"] {
   cursor: default;
   opacity: 0.7;
@@ -380,47 +402,6 @@
   .story-year-carousel {
     order: -1;
   }
-}
-
-.story-year-outcomes {
-  background: rgba(255, 255, 255, 0.72);
-  border-radius: 18px;
-  padding: clamp(14px, 2.4vw, 20px);
-  display: grid;
-  gap: 10px;
-  box-shadow: 0 10px 28px rgba(17, 24, 39, 0.12);
-}
-
-.story-year-outcomes-title {
-  margin: 0;
-  font-size: clamp(15px, 2.2vw, 18px);
-  color: #111827;
-}
-
-.story-year-outcomes ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 10px;
-}
-
-.story-year-outcomes li {
-  display: grid;
-  gap: 6px;
-}
-
-.story-year-outcome-code {
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(17, 24, 39, 0.6);
-}
-
-.story-year-outcome-text {
-  font-size: 13px;
-  line-height: 1.5;
-  color: rgba(17, 24, 39, 0.85);
 }
 
 .story-scene {
@@ -661,15 +642,6 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(17, 24, 39, 0.55);
-}
-
-.story-journey-track {
-  margin: 0;
-  font-size: clamp(16px, 2.4vw, 20px);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(17, 24, 39, 0.75);
 }
 
 .story-journey-image {


### PR DESCRIPTION
## Summary
- rename the Year 1–3 design tiles to “Design Studio” and surface their descriptive copy beneath a smaller title
- remove the programme outcomes/footer section from year scenes now that the design studio cards carry the key information
- tidy the related styling, introducing new classes for the compact title + subtitle layout

## Testing
- npm run lint *(fails: pre-existing lint errors in CompassChart, FrontagePage, HomePage, VideoPage, DestinationsScene, GlobalScene, VideoScene)*

------
https://chatgpt.com/codex/tasks/task_e_68dae483646c832a853358d61a1ee9c6