### PR TITLE
Fix lint issues across chart and story pages

### DIFF
--- a/src/components/CompassChart.jsx
+++ b/src/components/CompassChart.jsx
@@ -58,15 +58,6 @@ export default function CompassChart({ width = 700, height = 700, padding = 3, c
   // Center the solo band so it spans both concurrent bands plus the gap
   const soloR = outerR - (soloThickness / 2);
 
-  // Thin outer guide ring just outside modules
-  // Place thin ring so its inner edge touches the module outer edge
-  const thinR = outerR + thinBand / 2;   // inner edge = outerR
-
-  // Thin inner guide ring (Year 2) just inside modules (between Y1 and Y2)
-  const innerEdge = (topR - baseThickness / 2);               // inner boundary of Y1 modules
-  const ringGap = 6;                                          // desired radial gap between Y1 inner edge and Y2 ring
-  const innerThinR = innerEdge - ringGap - thinBand / 2;      // ring outer edge = innerEdge - ringGap
-
   // Year spacing: choose uniform spacing between the centre of each year's solo ring
   const YEAR_SPACING = 65; // px between centre of year solo rings (smaller -> rings closer together)
   // Use Year 1 soloR as the reference outermost module ring and compute Year 2/3 positions
@@ -79,8 +70,6 @@ export default function CompassChart({ width = 700, height = 700, padding = 3, c
   const y2BottomR = y2SoloR + y2SoloThickness / 2;
 
   // Year 3 band geometry (centered on computed soloR)
-  const innerEdge2 = y2TopR - baseThickness / 2; // inner boundary of Y2 modules
-  const innerThinR2 = innerEdge2 - ringGap - thinBand / 2; // separation ring to Y3 (kept for reference)
   const y3SoloThickness = baseThickness * 2 + gap;
   const y3TopR = y3SoloR - y3SoloThickness / 2;
   const y3BottomR = y3SoloR + y3SoloThickness / 2;

--- a/src/pages/FrontagePage.jsx
+++ b/src/pages/FrontagePage.jsx
@@ -115,9 +115,6 @@ function pushOutOfExclusion(word, exclusion) {
   const ry1 = y1 + r;
   const inside = (x > rx0 && x < rx1 && y > ry0 && y < ry1);
   if (!inside) return word;
-  const mag = Math.hypot(dx, dy) || 1;
-  const ux = dx / mag;
-  const uy = dy / mag;
   // Move the point to the edge of the inflated rect plus a small padding
   const targetX = x < cx ? rx0 - 6 : rx1 + 6;
   const targetY = y < cy ? ry0 - 6 : ry1 + 6;
@@ -129,13 +126,6 @@ function pushOutOfExclusion(word, exclusion) {
   return { ...word, left: leftPct, top: topPct };
 }
 
-
-function radiusToPct(word, exclusion) {
-  if (!exclusion) return 0; // defer until we can measure; tick loop will re-run
-  const rpx = estimateRadius(word);
-  const ref = Math.min(exclusion.cw || 1000, exclusion.ch || 1000);
-  return (rpx / ref) * 100; // percent of the limiting side
-}
 
 // Rectangle-based sizing & collision helpers
 function getSizePct(word, exclusion) {
@@ -289,6 +279,7 @@ export default function FrontagePage({ onNavigate }) {
   const wordRefs = useRef(new Map()); // id -> HTMLElement
   const [exclusion, setExclusion] = useState(null); // {x0,y0,x1,y1} in container pixels
   const exitTimerRef = useRef(null);
+  const initialisedRef = useRef(false);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return undefined;
@@ -330,6 +321,10 @@ export default function FrontagePage({ onNavigate }) {
 
   // Initialize active words on mount
   useEffect(() => {
+    if (initialisedRef.current) {
+      return;
+    }
+    initialisedRef.current = true;
     setActive(() => {
       const initial = [];
       while (initial.length < MAX_VISIBLE) {
@@ -344,7 +339,7 @@ export default function FrontagePage({ onNavigate }) {
       // We do not push out here because exclusion may be null, rely on animation tick
       return initial;
     });
-  }, []);
+  }, [exclusion]);
 
   useEffect(() => {
     if (reduceMotion) {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import CompassChart from "../components/CompassChart.jsx";
 import moduleInfo from "../data/moduleInfo.json";
 import programmeInfo from "../data/programmeInfo.json";
+
+const MotionDiv = motion.div;
 
 export default function HomePage({ onNavigate }) {
   const [infoModuleId, setInfoModuleId] = useState(null);
@@ -55,7 +57,7 @@ export default function HomePage({ onNavigate }) {
         <div className="panel details-panel">
           <AnimatePresence mode="wait">
             {!infoKey && (
-              <motion.div
+              <MotionDiv
                 key="programme"
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -79,7 +81,7 @@ export default function HomePage({ onNavigate }) {
                     </div>
                   );
                 })()}
-              </motion.div>
+              </MotionDiv>
             )}
             {infoKey && infoModuleId && (
               <div>

--- a/src/pages/VideoPage.jsx
+++ b/src/pages/VideoPage.jsx
@@ -29,7 +29,7 @@ function loadYouTubeIframeApi() {
       if (typeof previous === "function") {
         try {
           previous();
-        } catch (error) {
+        } catch {
           // ignore failures from earlier hooks
         }
       }
@@ -114,7 +114,7 @@ export default function VideoPage({ onNavigate }) {
       if (playerRef.current) {
         try {
           playerRef.current.destroy();
-        } catch (_err) {
+        } catch {
           // ignore cleanup errors
         }
         playerRef.current = null;

--- a/src/pages/story/scenes/DestinationsScene.jsx
+++ b/src/pages/story/scenes/DestinationsScene.jsx
@@ -3,7 +3,10 @@ import SceneHeading from "../components/SceneHeading.jsx";
 import usePrefersReducedMotion from "../hooks/usePrefersReducedMotion.js";
 
 export default function DestinationsScene({ scene }) {
-  const companies = scene?.companies || [];
+  const companies = useMemo(
+    () => (Array.isArray(scene?.companies) ? scene.companies : []),
+    [scene],
+  );
   const reduceMotion = usePrefersReducedMotion();
 
   const gridItems = useMemo(() => {

--- a/src/pages/story/scenes/GlobalScene.jsx
+++ b/src/pages/story/scenes/GlobalScene.jsx
@@ -39,7 +39,10 @@ function EuropeMapVisual() {
 }
 
 export default function GlobalScene({ scene }) {
-  const partners = Array.isArray(scene?.partners) ? scene.partners : [];
+  const partners = useMemo(
+    () => (Array.isArray(scene?.partners) ? scene.partners : []),
+    [scene],
+  );
   const [activeId, setActiveId] = useState(null);
   const [hoverId, setHoverId] = useState(null);
 

--- a/src/pages/story/scenes/VideoScene.jsx
+++ b/src/pages/story/scenes/VideoScene.jsx
@@ -27,7 +27,7 @@ function loadYouTubeIframeApi() {
       if (typeof previous === "function") {
         try {
           previous();
-        } catch (error) {
+        } catch {
           // ignore errors from previous handlers
         }
       }
@@ -85,7 +85,7 @@ export default function VideoScene({ scene }) {
       if (playerRef.current) {
         try {
           playerRef.current.destroy();
-        } catch (_err) {
+        } catch {
           // ignore cleanup failures
         }
         playerRef.current = null;


### PR DESCRIPTION
## Summary
- remove unused geometry constants from the compass chart to clear eslint warnings
- update the frontage keyword animation to avoid unused helpers and add a guarded dependency on the measured exclusion
- resolve remaining unused variable and dependency warnings across home, video, and story scenes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae9b2d8bc832abeed433b50dec745