### PR TITLE
Extend mobile bottom margin across slide layouts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -98,7 +98,16 @@ body { margin: 0; background: #FEC218; color: #111; font: 14px/1.45 "Arial Nova"
   :root { --header-space: 46px; }
 
   /* Reset landscape overrides when returning to portrait on phones */
-  .app-shell { overflow: auto; }
+  .app-shell {
+    overflow: auto;
+  }
+
+  .app-shell,
+  .frontage-page,
+  .story-page,
+  .video-page {
+    margin-bottom: 16px;
+  }
   .page-grid { height: auto; }
   .chart-panel { margin-top: 0 !important; z-index: 1; }
   .details-panel { z-index: 0; }


### PR DESCRIPTION
## Summary
- apply the 16px mobile bottom margin to the app shell, landing, story, and video slide containers so every view keeps consistent spacing on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db872554e4832aaf7c7cbadaed1ea1