### PR TITLE
Refine year carousels

### DIFF
--- a/src/data/storyScenes.json
+++ b/src/data/storyScenes.json
@@ -107,19 +107,19 @@
         {
           "track": "Design Studio",
           "deliverable": "Exploring your first neighbourhood project",
-          "image": "images/journey/year1-design.jpg",
+          "imageFolder": "firstyear/studio",
           "themes": ["Studio"]
         },
         {
           "track": "Technology & Environment",
           "deliverable": "Learning how buildings respond to climate",
-          "image": "images/journey/year1-technology.jpg",
+          "imageFolder": "firstyear/tech",
           "themes": ["Technology and Environment"]
         },
         {
           "track": "Practice & Context",
           "deliverable": "Discovering how places and people shape design",
-          "image": "images/journey/year1-humanities.jpg",
+          "imageFolder": "firstyear/context",
           "themes": ["Professional Practice and Behaviours", "Humanities"]
         }
       ],
@@ -135,19 +135,19 @@
         {
           "track": "Design Studio",
           "deliverable": "Designing larger urban spaces",
-          "image": "images/journey/year2-design.jpg",
+          "imageFolder": "secondyear/studio",
           "themes": ["Studio"]
         },
         {
           "track": "Technology & Environment",
           "deliverable": "Exploring building performance and comfort",
-          "image": "images/journey/year2-technology.jpg",
+          "imageFolder": "secondyear/tech",
           "themes": ["Technology and Environment"]
         },
         {
           "track": "Practice & Context",
           "deliverable": "Learning how design and practice fit together",
-          "image": "images/journey/year2-humanities.jpg",
+          "imageFolder": "secondyear/context",
           "themes": ["Professional Practice and Behaviours", "Humanities"]
         }
       ],
@@ -163,19 +163,19 @@
         {
           "track": "Design Studio",
           "deliverable": "Your final design thesis",
-          "image": "images/journey/year3-design.jpg",
+          "imageFolder": "thirdyear/studio",
           "themes": ["Studio"]
         },
         {
           "track": "Technology & Environment",
           "deliverable": "Showing how your ideas work in detail",
-          "image": "images/journey/year3-technology.jpg",
+          "imageFolder": "thirdyear/tech",
           "themes": ["Technology and Environment"]
         },
         {
           "track": "Practice & Context",
           "deliverable": "Presenting yourself as a future architect",
-          "image": "images/journey/year3-humanities.jpg",
+          "imageFolder": "thirdyear/context",
           "themes": ["Professional Practice and Behaviours", "Humanities"]
         }
       ],

--- a/src/pages/story/scenes/YearScene.jsx
+++ b/src/pages/story/scenes/YearScene.jsx
@@ -1,51 +1,219 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import SceneHeading from "../components/SceneHeading.jsx";
+
+const YEAR_CAROUSEL_GALLERIES = buildYearCarouselGalleries();
+const AUTO_ADVANCE_INTERVAL = 6000;
+
+function buildYearCarouselGalleries() {
+  const modules = import.meta.glob(
+    "../../../../images/**/*.{jpg,jpeg,png,gif,webp,avif,JPG,JPEG,PNG,GIF,WEBP,AVIF}",
+    {
+      eager: true,
+      import: "default",
+    },
+  );
+
+  const allowedYears = new Set(["firstyear", "secondyear", "thirdyear"]);
+  const galleries = Object.create(null);
+
+  for (const [path, moduleUrl] of Object.entries(modules)) {
+    const url = typeof moduleUrl === "string" ? moduleUrl : moduleUrl?.default;
+    if (!url) continue;
+
+    const normalisedPath = path.replace(/\\/g, "/");
+    const afterImages = normalisedPath.split("/images/")[1];
+    if (!afterImages) continue;
+
+    const segments = afterImages.split("/").filter(Boolean);
+    if (segments.length < 3) continue;
+
+    const [year, theme, ...rest] = segments;
+    const yearKey = year?.toLowerCase();
+    const themeKey = theme?.toLowerCase();
+    if (!yearKey || !themeKey || !allowedYears.has(yearKey)) continue;
+
+    const folderKey = `${yearKey}/${themeKey}`;
+    const filename = rest.join("/");
+    const label = deriveImageLabel(filename);
+
+    if (!galleries[folderKey]) {
+      galleries[folderKey] = [];
+    }
+
+    galleries[folderKey].push({
+      url,
+      filename,
+      label,
+    });
+  }
+
+  Object.keys(galleries).forEach((key) => {
+    galleries[key]
+      .sort((a, b) =>
+        a.filename.localeCompare(b.filename, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }),
+      )
+      .forEach((entry, index, array) => {
+        entry.index = index;
+        entry.count = array.length;
+      });
+  });
+
+  return galleries;
+}
+
+function deriveImageLabel(filename = "") {
+  const baseName = filename.split("/").pop()?.replace(/\.[^.]+$/, "");
+  if (!baseName) return "";
+
+  return baseName
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function normaliseFolderKey(folder) {
+  if (!folder) return null;
+  const cleaned = folder
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^images\//i, "")
+    .trim();
+
+  const segments = cleaned.split("/").filter(Boolean);
+  if (segments.length < 2) return null;
+
+  const [year, theme] = segments;
+  return `${year.toLowerCase()}/${theme.toLowerCase()}`;
+}
+
+function createSlidesForTile(tile, tileIndex) {
+  if (!tile) return [];
+
+  const folderKey = normaliseFolderKey(tile.imageFolder);
+  const gallery = folderKey ? YEAR_CAROUSEL_GALLERIES[folderKey] : null;
+
+  if (Array.isArray(gallery) && gallery.length) {
+    return gallery.map((entry, index, array) => {
+      const labelText = entry.label ? `${tile.track} — ${entry.label}` : tile.track;
+      return {
+        tileIndex,
+        track: tile.track,
+        deliverable: tile.deliverable,
+        image: entry.url,
+        imageLabel: entry.label,
+        altText: labelText,
+        slideIndex: index,
+        slideCount: array.length,
+      };
+    });
+  }
+
+  return [];
+}
 
 export default function YearScene({ scene }) {
   const tiles = Array.isArray(scene?.tiles) ? scene.tiles : [];
-  const slides = tiles
-    .map((tile, index) => (tile?.image ? { ...tile, tileIndex: index } : null))
-    .filter(Boolean);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const { tileSlides, firstInteractiveTileIndex } = useMemo(() => {
+    const slidesByTile = tiles.map((tile, index) => createSlidesForTile(tile, index));
+    const firstInteractive = slidesByTile.findIndex((entry) => entry.length > 0);
+    return {
+      tileSlides: slidesByTile,
+      firstInteractiveTileIndex: firstInteractive,
+    };
+  }, [tiles]);
+
+  const [activeTileIndex, setActiveTileIndex] = useState(() =>
+    firstInteractiveTileIndex !== -1 ? firstInteractiveTileIndex : 0,
+  );
+  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
 
   useEffect(() => {
-    if (!slides.length) {
-      setActiveIndex(0);
+    if (firstInteractiveTileIndex === -1) {
+      setActiveTileIndex(0);
+      setActiveSlideIndex(0);
       return;
     }
-    setActiveIndex((current) => {
-      if (current < 0 || current >= slides.length) {
+
+    setActiveTileIndex((current) => {
+      if (tileSlides[current]?.length) {
+        return current;
+      }
+      return firstInteractiveTileIndex;
+    });
+  }, [firstInteractiveTileIndex, tileSlides]);
+
+  useEffect(() => {
+    setActiveSlideIndex(0);
+  }, [activeTileIndex]);
+
+  useEffect(() => {
+    const slidesForTile = tileSlides[activeTileIndex];
+    if (!slidesForTile?.length) {
+      setActiveSlideIndex(0);
+      return;
+    }
+
+    setActiveSlideIndex((current) => {
+      if (current < 0 || current >= slidesForTile.length) {
         return 0;
       }
       return current;
     });
-  }, [slides.length]);
+  }, [activeTileIndex, tileSlides]);
 
-  const handleSelectSlide = (index) => {
+  const activeSlides = tileSlides[activeTileIndex] ?? [];
+  const activeSlideCount = activeSlides.length;
+  const hasAnySlides = tileSlides.some((entry) => entry.length > 0);
+  const activeSlide = activeSlides[activeSlideIndex] ?? null;
+
+  const handleSelectTile = (index) => {
     if (!Number.isInteger(index)) return;
-    setActiveIndex((current) => {
-      if (!slides.length) return current;
-      const boundedIndex = ((index % slides.length) + slides.length) % slides.length;
-      return boundedIndex;
-    });
+    const slidesForTile = tileSlides[index];
+    if (!slidesForTile?.length) return;
+    setActiveTileIndex(index);
   };
 
   const handleKeyDown = (event, index) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      handleSelectSlide(index);
+      handleSelectTile(index);
     }
   };
 
+  const handleSelectSlide = (index) => {
+    if (!Number.isInteger(index) || !activeSlideCount) return;
+    const boundedIndex = ((index % activeSlideCount) + activeSlideCount) % activeSlideCount;
+    setActiveSlideIndex(boundedIndex);
+  };
+
   const handlePrevious = () => {
-    if (!slides.length) return;
-    handleSelectSlide(activeIndex - 1);
+    if (!activeSlideCount) return;
+    handleSelectSlide(activeSlideIndex - 1);
   };
 
   const handleNext = () => {
-    if (!slides.length) return;
-    handleSelectSlide(activeIndex + 1);
+    if (!activeSlideCount) return;
+    handleSelectSlide(activeSlideIndex + 1);
   };
+
+  useEffect(() => {
+    if (activeSlideCount < 2 || typeof window === "undefined") return undefined;
+
+    const timer = window.setInterval(() => {
+      setActiveSlideIndex((current) => {
+        const nextIndex = current + 1;
+        return nextIndex >= activeSlideCount ? 0 : nextIndex;
+      });
+    }, AUTO_ADVANCE_INTERVAL);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [activeSlideCount, activeTileIndex]);
 
   return (
     <div className="story-scene story-scene--year">
@@ -53,13 +221,13 @@ export default function YearScene({ scene }) {
       <div className="story-year-layout">
         <div className="story-year-themes-column">
           {tiles.map((tile, index) => {
-            const slideIndex = slides.findIndex((slide) => slide.tileIndex === index);
-            const isInteractive = slideIndex !== -1;
-            const isActive = slideIndex === activeIndex && isInteractive;
+            const slidesForTile = tileSlides[index];
+            const isInteractive = Array.isArray(slidesForTile) && slidesForTile.length > 0;
+            const isActive = index === activeTileIndex && isInteractive;
 
             const handleInteraction = () => {
               if (!isInteractive) return;
-              handleSelectSlide(slideIndex);
+              handleSelectTile(index);
             };
 
             return (
@@ -75,7 +243,7 @@ export default function YearScene({ scene }) {
                 onFocus={handleInteraction}
                 onKeyDown={(event) => {
                   if (!isInteractive) return;
-                  handleKeyDown(event, slideIndex);
+                  handleKeyDown(event, index);
                 }}
               >
                 <div className="story-year-theme-header">
@@ -88,60 +256,90 @@ export default function YearScene({ scene }) {
             );
           })}
         </div>
-        {slides.length ? (
-          <div className="story-year-carousel" aria-live="polite">
-            <div className="story-year-carousel-viewport">
-              {slides.map((slide, index) => {
-                const isActive = index === activeIndex;
-                return (
-                  <figure
-                    key={`${slide.track}-${slide.image}`}
-                    className={`story-year-carousel-slide${isActive ? " is-active" : ""}`}
-                    style={{ backgroundImage: `url(${slide.image})` }}
-                    aria-hidden={!isActive}
-                  >
-                    <figcaption>
-                      <span className="story-year-carousel-track">{slide.track}</span>
-                    </figcaption>
-                  </figure>
-                );
-              })}
-              <button
-                type="button"
-                className="story-year-carousel-nav story-year-carousel-nav--previous"
-                onClick={handlePrevious}
-                aria-label="Previous project"
-              >
-                ‹
-              </button>
-              <button
-                type="button"
-                className="story-year-carousel-nav story-year-carousel-nav--next"
-                onClick={handleNext}
-                aria-label="Next project"
-              >
-                ›
-              </button>
+        <div
+          className={`story-year-carousel${hasAnySlides ? "" : " story-year-carousel--empty"}`}
+          aria-live="polite"
+        >
+          {hasAnySlides ? (
+            <>
+              <div className="story-year-carousel-viewport">
+                {activeSlides.map((slide, index) => {
+                  const isActive = index === activeSlideIndex;
+                  return (
+                    <figure
+                      key={`${slide.track}-${slide.image}-${index}`}
+                      className={`story-year-carousel-slide${isActive ? " is-active" : ""}`}
+                      style={{ backgroundImage: `url(${slide.image})` }}
+                      aria-hidden={!isActive}
+                    >
+                      <figcaption>
+                        <span className="story-year-carousel-track">{slide.track}</span>
+                        {slide.imageLabel ? (
+                          <span className="story-year-carousel-detail">{slide.imageLabel}</span>
+                        ) : null}
+                        {slide.slideCount > 1 ? (
+                          <span className="story-year-carousel-meta">
+                            {slide.slideIndex + 1} of {slide.slideCount}
+                          </span>
+                        ) : null}
+                      </figcaption>
+                    </figure>
+                  );
+                })}
+                <button
+                  type="button"
+                  className="story-year-carousel-nav story-year-carousel-nav--previous"
+                  onClick={handlePrevious}
+                  aria-label={
+                    activeSlide?.altText
+                      ? `Previous image for ${activeSlide.altText}`
+                      : "Previous project image"
+                  }
+                  disabled={activeSlideCount < 2}
+                >
+                  ‹
+                </button>
+                <button
+                  type="button"
+                  className="story-year-carousel-nav story-year-carousel-nav--next"
+                  onClick={handleNext}
+                  aria-label={
+                    activeSlide?.altText
+                      ? `Next image for ${activeSlide.altText}`
+                      : "Next project image"
+                  }
+                  disabled={activeSlideCount < 2}
+                >
+                  ›
+                </button>
+              </div>
+              {activeSlideCount > 1 ? (
+                <div className="story-year-carousel-dots" role="tablist" aria-label="Select project image">
+                  {activeSlides.map((slide, index) => {
+                    const isActive = index === activeSlideIndex;
+                    const labelText = slide.imageLabel ? `${slide.track} — ${slide.imageLabel}` : slide.track;
+                    return (
+                      <button
+                        key={`${slide.track}-dot-${index}`}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        className={`story-year-carousel-dot${isActive ? " is-active" : ""}`}
+                        onClick={() => handleSelectSlide(index)}
+                      >
+                        <span className="sr-only">{labelText}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="story-year-carousel-placeholder">
+              <p>Project imagery coming soon.</p>
             </div>
-            <div className="story-year-carousel-dots" role="tablist" aria-label="Select project">
-              {slides.map((slide, index) => {
-                const isActive = index === activeIndex;
-                return (
-                  <button
-                    key={`${slide.track}-dot`}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    className={`story-year-carousel-dot${isActive ? " is-active" : ""}`}
-                    onClick={() => handleSelectSlide(index)}
-                  >
-                    <span className="sr-only">{slide.track}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ) : null}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -277,6 +277,7 @@
   background-size: cover;
   background-position: center;
   border-radius: 22px;
+  margin: 0;
   opacity: 0;
   transform: scale(0.96);
   transition: opacity 420ms ease, transform 420ms ease;
@@ -316,6 +317,19 @@
   opacity: 0.85;
 }
 
+.story-year-carousel-detail {
+  font-size: clamp(18px, 2.4vw, 22px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.story-year-carousel-meta {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
 
 .story-year-carousel-nav {
   position: absolute;
@@ -333,6 +347,11 @@
   display: grid;
   place-items: center;
   transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.story-year-carousel-nav:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .story-year-carousel-nav--previous {
@@ -380,6 +399,25 @@
 .story-year-carousel-dot:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.85);
   outline-offset: 2px;
+}
+
+.story-year-carousel--empty {
+  display: flex;
+  align-items: center;
+}
+
+.story-year-carousel-placeholder {
+  flex: 1;
+  min-height: clamp(240px, 36vw, 420px);
+  border-radius: 22px;
+  background: rgba(17, 24, 39, 0.1);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: rgba(17, 24, 39, 0.68);
+  font-size: clamp(14px, 2vw, 16px);
+  letter-spacing: 0.02em;
+  padding: 24px;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- pull the new first, second, and third year galleries into the story carousel via import.meta.glob
- allow each strand to cycle through its gallery automatically with captions, placeholder messaging, and no stale fallback image paths
- style the carousel so slides fill the frame edge-to-edge while keeping dot navigation and empty states aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db8d1c62e4832abcb49a689d76a713