### PR TITLE
Adjust year carousel transition timing

### DIFF
--- a/src/pages/story/scenes/YearScene.jsx
+++ b/src/pages/story/scenes/YearScene.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import SceneHeading from "../components/SceneHeading.jsx";
 
 const YEAR_CAROUSEL_GALLERIES = buildYearCarouselGalleries();
-const AUTO_ADVANCE_INTERVAL = 6000;
+const AUTO_ADVANCE_INTERVAL = 10000;
 
 function buildYearCarouselGalleries() {
   const modules = import.meta.glob(

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -280,7 +280,7 @@
   margin: 0;
   opacity: 0;
   transform: scale(0.96);
-  transition: opacity 420ms ease, transform 420ms ease;
+  transition: opacity 720ms ease-in-out, transform 720ms ease-in-out;
 }
 
 .story-year-carousel-slide::after {


### PR DESCRIPTION
## Summary
- slow the year carousel auto-advance interval so slides linger longer
- lengthen slide transition animations to emphasise the fade between images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db96258904832ab6c90b6f6cd8baba