### PR TITLE
Redesign professional pathway story slide

### DIFF
--- a/src/data/storyScenes.json
+++ b/src/data/storyScenes.json
@@ -481,11 +481,55 @@
       "title": "Next steps - Your Professional Pathway",
       "headline": "Part 1 (BSc) → Practice → Part 2 → Part 3 → Register with ARB.",
       "steps": [
-        "BSc Architecture (Part 1)",
-        "Practice experience",
-        "MArch / Part 2",
-        "Part 3 Professional Exam",
-        "Register with ARB"
+        {
+          "id": "part1",
+          "stage": "Part I",
+          "title": "BSc Architecture",
+          "description": "Three-year honours degree giving you a RIBA Part 1-ready foundation."
+        },
+        {
+          "id": "practice",
+          "stage": "Practice",
+          "title": "Professional Experience",
+          "description": "Log at least 12 months of PEDR-recorded experience in practice."
+        },
+        {
+          "id": "part2",
+          "stage": "Part II",
+          "title": "MArch Architecture",
+          "description": "Advance your design research and complete the RIBA Part 2 award."
+        },
+        {
+          "id": "part3",
+          "stage": "Part III",
+          "title": "Professional Practice",
+          "description": "Prepare for final assessments covering contracts, law and management."
+        },
+        {
+          "id": "arb",
+          "stage": "Register",
+          "title": "Join the ARB",
+          "description": "Apply for UK registration and continue your lifelong CPD."
+        }
+      ],
+      "note": {
+        "title": "PEDR professional practice",
+        "description": "Your experience is recorded between academic stages using the RIBA PEDR logbook, keeping you on track for chartered status."
+      },
+      "accreditationDescription": "Our BSc Architecture is accredited by the Royal Institute of British Architects (RIBA) and recognised by the Board of Architects Malaysia, giving your degree global portability.",
+      "accreditations": [
+        {
+          "id": "riba",
+          "label": "RIBA Validated",
+          "image": "images/story/riba-2.gif",
+          "alt": "Royal Institute of British Architects validation logo"
+        },
+        {
+          "id": "lam",
+          "label": "Board of Architects Malaysia",
+          "image": "images/story/BAM.gif",
+          "alt": "Board of Architects Malaysia (LAM) accreditation logo"
+        }
       ],
       "cta": {
         "label": "Request a visit",

--- a/src/pages/story/scenes/PathwayScene.jsx
+++ b/src/pages/story/scenes/PathwayScene.jsx
@@ -1,19 +1,74 @@
 import SceneHeading from "../components/SceneHeading.jsx";
 
+function resolveAsset(path) {
+  if (!path) {
+    return "";
+  }
+
+  if (/^https?:/i.test(path)) {
+    return path;
+  }
+
+  try {
+    return new URL(`../../../../${path}`, import.meta.url).href;
+  } catch (error) {
+    console.warn("Unable to resolve asset", path, error);
+    return path;
+  }
+}
+
 export default function PathwayScene({ scene }) {
+  const steps = scene?.steps || [];
+  const accreditations = scene?.accreditations || [];
+
   return (
     <div className="story-scene story-scene--pathway">
       <SceneHeading scene={scene} />
       <div className="story-pathway">
-        {(scene?.steps || []).map((step, index) => (
-          <div key={step} className="story-pathway-step">
-            <div className="story-pathway-node">
-              <span>{index + 1}</span>
-            </div>
-            <p>{step}</p>
+        <div className="story-pathway-track" role="list">
+          {steps.map((step, index) => {
+            const key = step?.id || step?.title || index;
+            const cardClass = ["story-pathway-card", step?.id ? `story-pathway-card--${step.id}` : ""].filter(Boolean).join(" ");
+
+            return (
+              <article key={key} className={cardClass} role="listitem">
+                {step?.stage ? <span className="story-pathway-stage">{step.stage}</span> : null}
+                {step?.title ? <h3 className="story-pathway-title">{step.title}</h3> : null}
+                {step?.description ? <p className="story-pathway-description">{step.description}</p> : null}
+              </article>
+            );
+          })}
+        </div>
+
+        {scene?.note?.title || scene?.note?.description ? (
+          <div className="story-pathway-note">
+            {scene.note.title ? <p className="story-pathway-note-title">{scene.note.title}</p> : null}
+            {scene.note.description ? <p>{scene.note.description}</p> : null}
           </div>
-        ))}
+        ) : null}
+
+        {scene?.accreditationDescription || accreditations.length ? (
+          <section className="story-pathway-accreditation" aria-label="Course accreditations">
+            {scene?.accreditationDescription ? <p>{scene.accreditationDescription}</p> : null}
+            {accreditations.length ? (
+              <div className="story-pathway-logos">
+                {accreditations.map((logo, index) => {
+                  const key = logo?.id || logo?.label || logo?.image || index;
+                  const src = resolveAsset(logo?.image);
+
+                  return (
+                    <figure key={key} className="story-pathway-logo">
+                      {logo?.image ? <img src={src} alt={logo?.alt || logo?.label || ""} loading="lazy" /> : null}
+                      {logo?.label ? <figcaption className="story-pathway-logo-label">{logo.label}</figcaption> : null}
+                    </figure>
+                  );
+                })}
+              </div>
+            ) : null}
+          </section>
+        ) : null}
       </div>
+
       {scene?.cta?.href ? (
         <div className="story-pathway-cta">
           <a className="btn" href={scene.cta.href} target="_blank" rel="noreferrer">

--- a/src/pages/story/storyPage.css
+++ b/src/pages/story/storyPage.css
@@ -1668,36 +1668,182 @@
 }
 
 .story-pathway {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 18px;
-  justify-content: space-between;
+  display: grid;
+  gap: clamp(24px, 4vw, 40px);
 }
 
-.story-pathway-step {
-  flex: 1 1 160px;
+.story-pathway-track {
   display: grid;
-  gap: 10px;
+  grid-template-columns: 1fr;
+  gap: clamp(18px, 4vw, 28px);
+}
+
+.story-pathway-card {
+  --story-pathway-color: #0f172a;
+  position: relative;
+  border-radius: 24px;
+  padding: clamp(22px, 3.2vw, 30px) clamp(18px, 4vw, 28px);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid color-mix(in srgb, var(--story-pathway-color) 28%, transparent);
+  background: #ffffff;
+  background: color-mix(in srgb, var(--story-pathway-color) 8%, #ffffff 92%);
+  box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 12px;
+  text-align: center;
+  min-height: 186px;
+}
+
+.story-pathway-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  border-radius: 24px 24px 0 0;
+  background: var(--story-pathway-color);
+}
+
+.story-pathway-card:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: calc(-1 * clamp(24px, 4vw, 34px));
+  transform: translateX(-50%);
+  width: 4px;
+  height: clamp(24px, 4vw, 34px);
+  background: rgba(15, 23, 42, 0.22);
+  background: color-mix(in srgb, var(--story-pathway-color) 60%, transparent);
+}
+
+.story-pathway-stage {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--story-pathway-color) 70%, #1f2937 30%);
+}
+
+.story-pathway-title {
+  font-size: clamp(1.1rem, 3vw, 1.35rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.story-pathway-description {
+  font-size: clamp(0.95rem, 2.6vw, 1.05rem);
+  color: #374151;
+}
+
+.story-pathway-card--part1 {
+  --story-pathway-color: #06b6d4;
+}
+
+.story-pathway-card--practice {
+  --story-pathway-color: #6366f1;
+}
+
+.story-pathway-card--part2 {
+  --story-pathway-color: #0ea5e9;
+}
+
+.story-pathway-card--part3 {
+  --story-pathway-color: #f59e0b;
+}
+
+.story-pathway-card--arb {
+  --story-pathway-color: #f97316;
+}
+
+.story-pathway-note {
+  text-align: center;
+  max-width: min(520px, 90%);
+  margin: 0 auto;
+  display: grid;
+  gap: 6px;
+  color: #1f2937;
+}
+
+.story-pathway-note-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.story-pathway-accreditation {
+  display: grid;
+  gap: clamp(18px, 3vw, 26px);
   text-align: center;
 }
 
-.story-pathway-node {
-  width: 56px;
-  height: 56px;
+.story-pathway-accreditation > p {
   margin: 0 auto;
-  border-radius: 50%;
-  background: #111827;
-  color: #fff;
+  max-width: min(640px, 92%);
+  color: #1f2937;
+  font-size: clamp(0.95rem, 2.6vw, 1.05rem);
+}
+
+.story-pathway-logos {
   display: flex;
+  gap: clamp(18px, 5vw, 40px);
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+}
+
+.story-pathway-logo {
+  display: grid;
+  gap: 10px;
+  justify-items: center;
+}
+
+.story-pathway-logo img {
+  max-height: clamp(60px, 12vw, 86px);
+  width: auto;
+}
+
+.story-pathway-logo-label {
+  font-size: 0.85rem;
   font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #374151;
 }
 
 .story-pathway-cta {
   margin-top: 24px;
   display: flex;
   justify-content: center;
+}
+
+@media (max-width: 959px) {
+  .story-pathway-card {
+    min-height: auto;
+  }
+}
+
+@media (min-width: 960px) {
+  .story-pathway-track {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    align-items: stretch;
+  }
+
+  .story-pathway-card {
+    min-height: clamp(220px, 28vw, 260px);
+  }
+
+  .story-pathway-card:not(:last-child)::after {
+    left: auto;
+    bottom: auto;
+    top: 50%;
+    right: clamp(-20px, -4vw, -16px);
+    width: clamp(32px, 4vw, 48px);
+    height: 4px;
+    transform: translateY(-50%);
+  }
 }
 
 @media (max-width: 960px) {
@@ -1825,49 +1971,3 @@
   }
 }
 
-  .story-pathway-track {
-    flex-direction: column;
-    gap: 22px;
-  }
-
-  .story-pathway-step:not(:last-child)::after {
-    right: auto;
-    left: 50%;
-    top: auto;
-    bottom: -22px;
-    width: 4px;
-    height: 22px;
-    transform: translateX(-50%);
-  }
-
-  .story-pathway-card {
-    min-height: auto;
-    padding: 20px 18px;
-  }
-
-
-.story-pathway-logos {
-  display: flex;
-  gap: 32px;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.story-pathway-logo {
-  display: grid;
-  gap: 10px;
-  justify-items: center;
-}
-
-.story-pathway-logo img {
-  max-height: 72px;
-  width: auto;
-}
-
-.story-pathway-logo-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}


### PR DESCRIPTION
## Summary
- replace the pathway scene data with structured step, note, and accreditation content
- rebuild the pathway scene to render responsive cards, connectors, and accreditation logos with resolved assets
- refresh the pathway styling so the diagram is horizontal on wide screens, vertical on small screens, and includes accreditation messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc1d2d0b90832aaa71aef6aa030b84